### PR TITLE
Task SSSDB-1 ready (version 1.1.0)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,6 @@ import PackageDescription
 let package = Package(
     name: "SSDB",
     dependencies: [
-        .Package(url: "https://github.com/vapor/sockets.git", majorVersion: 0)
+        .Package(url: "https://github.com/IBM-Swift/BlueSocket", majorVersion: 0)
     ]
 )

--- a/Tests/SSDBTests/SSDBTests.swift
+++ b/Tests/SSDBTests/SSDBTests.swift
@@ -3,7 +3,9 @@ import XCTest
 
 class SSDBTests: XCTestCase {
     func testExample() {
-        // TODO, sry
+        let connection = SSDB(host: "127.0.0.1", port: 8888, password: "zuD6mgCusMf6qpSGJ6iKukU28ztIyjL1", keepAlive: true)
+//        dump(String(data: (try! connection.get(key: "Character:6226657c-23cf-455d-aeb2-ab29eefd34c9"))!, encoding: .ascii))
+        print(try! connection.get(key: "Character:6226657c-23cf-455d-aeb2-ab29eefd34c9", encoding: .isoLatin1))
     }
 
     static var allTests = [


### PR DESCRIPTION
* Migrated from [Vapor/Sockets](https://github.com/vapor/sockets) to [IBM/BlueSocket](https://github.com/IBM-Swift/BlueSocket) (Issue #2)
* Added `info` method and `get` method returning `String`
* `Response` struct now has `toString` method, converting response `Data` to `String` with given `encoding` (`ascii` by default)
* More public methods and properties
* Incorrect response parsing fixed (found during testing `info` command)